### PR TITLE
Remove vim right click menu

### DIFF
--- a/roles/neovim/files/etc/vim/completion.vim
+++ b/roles/neovim/files/etc/vim/completion.vim
@@ -3,7 +3,11 @@ set pumheight=15
 
 
 lua <<EOF
-  -- Setup nvim-cmp.
+   vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+    vim.lsp.diagnostic.on_publish_diagnostics, {
+      virtual_text = false
+    }
+  ) -- Setup nvim-cmp.
   local has_words_before = function()
     local line, col = unpack(vim.api.nvim_win_get_cursor(0))
     return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil

--- a/roles/neovim/files/etc/vim/nerdtree.vim
+++ b/roles/neovim/files/etc/vim/nerdtree.vim
@@ -1,11 +1,11 @@
 " Start NERDTree if no file argument
 function! StartUp()
     if !argc() && !exists("s:std_in")
-        NERDTree
+        silent! NERDTree
     end
     if argc() && isdirectory(argv()[0]) && !exists("s:std_in")
         ene
-        exe 'NERDTree' argv()[0]
+        exe 'silent! NERDTree' argv()[0]
         cd `=argv()[0]`
     end
 endfunction

--- a/roles/neovim/files/etc/vimrc
+++ b/roles/neovim/files/etc/vimrc
@@ -5,6 +5,7 @@ set nofixendofline
 
 "enable mouse support
 set mouse=a
+set mousemodel=extend
 
 set runtimepath+=/etc/vim,~/.vim,/var/lib/vim/addons,/usr/share/vim/vimfiles,/usr/share/vim/vim74,/usr/share/vim/vimfiles/after,/var/lib/vim/addons/after,~/.vim/after
 set suffixes=.bak,~,.swp,.o,.info,.aux,.log,.dvi,.bbl,.blg,.brf,.cb,.ind,.idx,.ilg,.inx,.out,.toc

--- a/roles/wm/qtile/templates/HOME/.config/qtile/config.py.j2
+++ b/roles/wm/qtile/templates/HOME/.config/qtile/config.py.j2
@@ -34,6 +34,8 @@ from libqtile.log_utils import logger
 
 mod = "mod4"
 hyper = "mod3"
+alt = "mod1"
+
 terminal = guess_terminal()
 
 
@@ -194,6 +196,8 @@ def focus_left(qtile):
             if w._x > qtile.current_window._x:
                 w.cmd_focus()
 
+def nop(qtile):
+    pass
 
 keys = [
     # A list of available commands that can be bound to keys can be found
@@ -231,6 +235,7 @@ keys = [
     Key([mod], "n", lazy.function(next_free_empty_group), desc="Next free empty group"),
     Key([mod], "m", lazy.window.toggle_minimize()),
     Key([mod], "f", lazy.window.toggle_fullscreen()),
+    Key(["control", alt], "Tab", lazy.function(nop)), # Ignore evil mouse button on work computer
     # Toggle between split and unsplit sides of stack.
     # Split = all windows displayed
     # Unsplit = 1 window displayed, like Max layout, but still with


### PR DESCRIPTION
- Fix Invalid character in group
- Remove inline LSP warnings
- Disable annoying right click menu in vim
